### PR TITLE
Create figure 8: look at 2class predictions

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-all: pylint.log figure1.svg figure2.svg figure3.svg figure4.svg figure5.svg figure6.svg figure7.svg
+all: pylint.log figure1.svg figure2.svg figure3.svg figure4.svg figure5.svg figure6.svg figure7.svg figure8.svg
 venv: venv/bin/activate
 
 venv/bin/activate: requirements.txt

--- a/syserol/figures/figure8.py
+++ b/syserol/figures/figure8.py
@@ -1,0 +1,38 @@
+"""
+This creates Figure 8.
+"""
+
+import numpy as np
+from syserol.figures.common import subplotLabel, getSetup
+from syserol.dataImport import createCube
+from syserol.model import SVM_2class_predictions
+from syserol.tensor import perform_CMTF
+
+def makeFigure():
+    """ Plot CP and NV SVM.SVC Prediction Accuracy Scores as Components for Decomposition Increase"""
+    ax, f = getSetup((10, 10), (2, 1))
+    cube, glyCube = createCube()
+    cp_list = np.zeros(10)
+    nv_list = np.zeros(10)
+    for i in np.arange(1, 11):
+        tensorFac, _, _ = perform_CMTF(cube, glyCube, i)
+        cp_accuracy, nv_accuracy = SVM_2class_predictions(tensorFac[1][0])
+        cp_list[i-1] = cp_accuracy
+        nv_list[i-1] = nv_accuracy
+
+    # Plotting 
+    ax[0].plot(np.arange(1, 11), cp_list)
+    ax[0].set_xlabel("Number of Components", fontsize=12)
+    ax[0].set_ylabel("Accuracy Score", fontsize=12)
+    ax[0].set_title("Controller/Progressor Class Prediction Accuracy for Increasing Component Decompositions", fontsize=15)
+    ax[0].set_xlim(1, 10)
+
+    ax[1].plot(np.arange(1, 11), nv_list)
+    ax[1].set_xlabel("Number of Components", fontsize=12)
+    ax[1].set_ylabel("Accuracy Score", fontsize=12)
+    ax[1].set_title("Viremic/Non-Viremic Class Prediction Accuracy for Increasing Component Decompositions", fontsize=15)
+    ax[1].set_xlim(1, 10)
+
+    subplotLabel(ax)
+    
+    return f

--- a/syserol/model.py
+++ b/syserol/model.py
@@ -9,7 +9,7 @@ from sklearn.svm import SVC
 from scipy.stats import zscore
 from tensorly.kruskal_tensor import kruskal_to_tensor
 from syserol.tensor import perform_CMTF
-from syserol.dataImport import createCube, importFunction, importGlycan
+from syserol.dataImport import createCube, importFunction, importGlycan, load_file
 
 
 def test_predictions(function="ADCD"):


### PR DESCRIPTION
Figure 8 so far has plots of the accuracy scores for Controller/Progressor predictions and NonViremic/Viremic predictions as the number of components used for decomposition increases. If we also want plots of predicted vs. actual values for different components, I can change what 2class_SVM_class_predictions returns to plot that info.