### PR TITLE
remove functions

### DIFF
--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -92,7 +92,6 @@ def createCube():
 
     IGG = importIGG()
     glycan, dfGlycan = importGlycan()
-    df_merged = load_file("data-glycan-gp120")
     glyCube = np.full([len(subjects), len(glycan)], np.nan)
 
     for k, curAnti in enumerate(antigen):
@@ -100,16 +99,11 @@ def createCube():
 
         for i, curSubj in enumerate(subjects):
             subjLumx = lumx[lumx["subject"] == curSubj]
-            if df_merged["subject"].isin([curSubj]).any():
-                subjGly = df_merged[df_merged["subject"] == curSubj]
-                subjGly = subjGly.drop(["subject"], axis=1)
-            else:
-                subjGly = pd.DataFrame(np.nan, index=[0], columns=range(25))
-                my_columns = glycan
-                subjGly.columns = my_columns
+            subjGly = dfGlycan[dfGlycan["subject"] == curSubj]
 
-            for j, col in enumerate(subjGly):
-                glyCube[i, j] = subjGly[col]
+            for _, row in subjGly.iterrows():
+                j = glycan.index(row["variable"])
+                glyCube[i, j] = row["value"]
 
             for _, row in subjLumx.iterrows():
                 j = detections.index(row["variable"])

--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -81,7 +81,7 @@ def importFunction():
     idnum = [0, 1, 2, 3, 4, 5]
     mapped = dict(zip(functions, idnum))
 
-    return
+    return df, mapped
 
 
 @lru_cache()

--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -99,7 +99,8 @@ def createCube():
         lambda left, right: pd.merge(left, right, on=["subject"], how="outer"),
         data_frames,
     )
-    glyCube = np.full([len(subjects), len(glycan) + 6], np.nan)
+    df_merged = df_merged.drop(["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"], axis=1)
+    glyCube = np.full([len(subjects), len(glycan)], np.nan)
 
     for k, curAnti in enumerate(antigen):
         lumx = importLuminex(curAnti)

--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -92,14 +92,7 @@ def createCube():
 
     IGG = importIGG()
     glycan, dfGlycan = importGlycan()
-    dfGlycan = dfGlycan.pivot(index="subject", columns="variable", values="value")
-    func, _ = importFunction()
-    data_frames = [dfGlycan, func]
-    df_merged = reduce(
-        lambda left, right: pd.merge(left, right, on=["subject"], how="outer"),
-        data_frames,
-    )
-    df_merged = df_merged.drop(["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"], axis=1)
+    df_merged = load_file("data-glycan-gp120")
     glyCube = np.full([len(subjects), len(glycan)], np.nan)
 
     for k, curAnti in enumerate(antigen):
@@ -107,8 +100,13 @@ def createCube():
 
         for i, curSubj in enumerate(subjects):
             subjLumx = lumx[lumx["subject"] == curSubj]
-            subjGly = df_merged[df_merged["subject"] == curSubj]
-            subjGly = subjGly.drop(["subject"], axis=1)
+            if df_merged["subject"].isin([curSubj]).any():
+                subjGly = df_merged[df_merged["subject"] == curSubj]
+                subjGly = subjGly.drop(["subject"], axis=1)
+            else:
+                subjGly = pd.DataFrame(np.nan, index=[0], columns=range(25))
+                my_columns = glycan
+                subjGly.columns = my_columns
 
             for j, col in enumerate(subjGly):
                 glyCube[i, j] = subjGly[col]

--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -81,7 +81,7 @@ def importFunction():
     idnum = [0, 1, 2, 3, 4, 5]
     mapped = dict(zip(functions, idnum))
 
-    return df, mapped
+    return
 
 
 @lru_cache()

--- a/syserol/figures/figure10.py
+++ b/syserol/figures/figure10.py
@@ -40,7 +40,6 @@ def makeFigure():
     _, detections, antigen = getAxes()
     subjinfo = load_file("meta-subjects")
 
-    functions = ["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]
     index = [0, 2, 4]
     place = [0, 4, 8]
     # Build Figure
@@ -188,14 +187,14 @@ def makeFigure():
         c.set_xlim(-xmax, xmax)
         c.set_ylim(-ymax, ymax)
 
-        # Glycans/Functions
+        # Glycans
         values1 = glyc[:, i]
         values2 = glyc[:, i + 1]
         data = {
             f"Component {i+1}": values1,
             f"Component {i+2}": values2,
-            "G": np.concatenate((np.array(glycaninf["GS"]), functions)),
-            "FB": np.concatenate((np.array(glycaninf["FB"]), ["Function"] * 6)),
+            "G": glycaninf["GS"],
+            "FB": glycaninf["FB"],
         }
         df = pd.DataFrame(data)
         xmax = np.amax(np.absolute(values1))
@@ -217,6 +216,6 @@ def makeFigure():
     ax[0].set_title("Subjects", fontsize=15)
     ax[1].set_title("Receptors", fontsize=15)
     ax[2].set_title("Antigens", fontsize=15)
-    ax[3].set_title("Glycans/Functions", fontsize=15)
+    ax[3].set_title("Glycans", fontsize=15)
 
     return f

--- a/syserol/figures/figure7.py
+++ b/syserol/figures/figure7.py
@@ -10,7 +10,6 @@ from syserol.model import noCMTF_function_prediction
 def makeFigure():
     """ Analyze Prediction Accuracy of 10 Fold Cross Validation Strategy"""
     ax, f = getSetup((10, 10), (3, 2))
-    #matrix = Function_Prediction_10FoldCV(6)
     functions = ["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]
     # Plot Actual vs. Predicted Values for each Function
     for i, func in enumerate(functions):       

--- a/syserol/figures/figure7.py
+++ b/syserol/figures/figure7.py
@@ -4,28 +4,25 @@ This creates Figure 7.
 import numpy as np
 from sklearn.metrics import r2_score
 from syserol.figures.common import subplotLabel, getSetup
-from syserol.model import Function_Prediction_10FoldCV
+from syserol.model import noCMTF_function_prediction
 
 
 def makeFigure():
     """ Analyze Prediction Accuracy of 10 Fold Cross Validation Strategy"""
     ax, f = getSetup((10, 10), (3, 2))
-    matrix = Function_Prediction_10FoldCV(6)
+    #matrix = Function_Prediction_10FoldCV(6)
     functions = ["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]
     # Plot Actual vs. Predicted Values for each Function
-    for i in np.arange(6):
-        x = matrix[0:181, i]
-        y = matrix[0:181, i + 6]
+    for i, func in enumerate(functions):       
+        x, y, accuracy = noCMTF_function_prediction(components=6, function=func)
         ax[i].scatter(x, y)
         ax[i].set_xlabel("Actual Values", fontsize=12)
         ax[i].set_ylabel("Predicted Values", fontsize=12)
-        idx = np.isfinite(x)
-        r2 = r2_score(x[idx], y[idx])  # coefficient of determination
-        m, b = np.polyfit(x[idx], y[idx], 1)  # line of best fit
+        m, b = np.polyfit(x, y, 1)  # line of best fit
         ax[i].plot(x, m * x + b, 'k--', color="red")
-        ax[i].text(1, 1, fr"$R^2$ Score: {round(r2, 3)}", {"color": "red", "fontsize": 10}, horizontalalignment="right",
+        ax[i].text(1, 1, f"Accuracy Score: {round(accuracy, 3)}", {"color": "red", "fontsize": 10}, horizontalalignment="right",
                    verticalalignment="bottom", transform=ax[i].transAxes)
-        ax[i].set_title(functions[i], fontsize=15)
+        ax[i].set_title(func, fontsize=15)
 
     subplotLabel(ax)
     return f

--- a/syserol/figures/figure9.py
+++ b/syserol/figures/figure9.py
@@ -16,7 +16,8 @@ from syserol.dataImport import (
     getAxes,
 )
 from syserol.model import (
-    Function_Prediction_10FoldCV,
+    noCMTF_function_prediction,
+    ourSubjects_function_prediction,
     SVM_2class_predictions,
 )
 from sklearn.metrics import r2_score
@@ -27,19 +28,14 @@ from syserol.tensor import perform_CMTF
 def makeFigure():
     """ Show Similarity in Prediction of Alter Model and Our Model"""
     # Gather Function Prediction Accuracies
-    arry = Function_Prediction_10FoldCV(6)  # Our Function Predictions in an array
-    _, mapped = importFunction()
+    functions = ["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]
     accuracies = np.zeros(12)
-    for ii, func in enumerate(mapped):
+    for ii, func in enumerate(functions):
         _, _, acc = function_elastic_net(func)  # Alter Function Predictions
         accuracies[ii] = acc  # store accuracies
-    for i in np.arange(6):
-        x = arry[0:181, i]
-        y = arry[0:181, i + 6]
-        idx = np.isfinite(x)
-        accuracies[i + 6] = np.sqrt(
-            r2_score(x[idx], y[idx])
-        )  # Calculate our accuracies & store
+    for i, func in enumerate(functions):
+        _, _, accuracy = noCMTF_function_prediction(components=6, function=func) # our prediction accuracies
+        accuracies[i+6] = accuracy #store
 
     # Create DataFrame
     model = np.array(
@@ -77,30 +73,13 @@ def makeFigure():
     data = {"Accuracy": accuracies, "Model": model, "Function": function}
     functions = pd.DataFrame(data)  # Function Prediction DataFrame, Figure 2B
 
-    # Gather function predictions for subjects left out of Alter
-    # arry = Function_Prediction_10FoldCV(6) (line 22)
-    # Re-Create Alter DataFrame with leftout subjects
-    df = importLuminex()
-    lum = df.pivot(index="subject", columns="variable", values="value")
-    _, df2 = importGlycan()
-    glyc = df2.pivot(index="subject", columns="variable", values="value")
-    func, _ = importFunction()
-    igg = importIGG()
-    igg = igg.pivot(index="subject", columns="variable", values="value")
-    data_frames = [lum, glyc, func, igg]
-    df_merged = reduce(
-        lambda left, right: pd.merge(left, right, on=["subject"], how="inner"),
-        data_frames,
-    )
-    df_merged = df_merged.dropna()  # Final Alter DataFrame
-    fullsubj = np.array(df_merged["subject"])  # Subjects only included in Alter
-    leftout = []
-    subjects, _, _ = getAxes()
-    for index, i in enumerate(subjects):
-        if i not in fullsubj:
-            leftout.append((index, i))  # Subjects left out of Alter
-    indices = [i[0] for i in leftout]
-    preds = arry[indices, :]
+    preds = np.zeros([81, 12])
+    # Subjects left out of Alter
+    for i, func in enumerate(functions):
+        Y, Y_pred = ourSubjects_function_prediction(components=6, function=func)
+        preds[:, i] = Y
+        preds[:, i+6] = Y_pred
+    
     df = pd.DataFrame(
         preds,
         columns=[

--- a/syserol/figures/figure9.py
+++ b/syserol/figures/figure9.py
@@ -71,10 +71,10 @@ def makeFigure():
         ]
     )
     data = {"Accuracy": accuracies, "Model": model, "Function": function}
-    functions = pd.DataFrame(data)  # Function Prediction DataFrame, Figure 2B
+    functions_df = pd.DataFrame(data)  # Function Prediction DataFrame, Figure 2B
 
-    preds = np.zeros([81, 12])
     # Subjects left out of Alter
+    preds = np.zeros([81, 12])
     for i, func in enumerate(functions):
         Y, Y_pred = ourSubjects_function_prediction(components=6, function=func)
         preds[:, i] = Y
@@ -141,7 +141,7 @@ def makeFigure():
         hue="Model",
         markers=["o", "x"],
         join=False,
-        data=functions,
+        data=functions_df,
         ax=ax[0],
     )
     # Formatting

--- a/syserol/model.py
+++ b/syserol/model.py
@@ -36,35 +36,6 @@ def test_predictions(function="ADCD"):
     return corr
 
 
-def Function_Prediction_10FoldCV(components=10):
-    """ 10 Fold Cross Validation to Test Function Predictive Abilities"""
-    cube, glyCube = createCube()
-    glycan, _ = importGlycan()
-
-    X = glyCube
-    matrix = np.zeros([181, 12])
-
-    kf = KFold(n_splits=10, shuffle=True)  # split into 10 folds
-    for _, test_index in kf.split(X):  # run cross validation
-        copy = (
-            glyCube.copy()
-        )  # copy & restore original values at start of each cross validation fold
-        matrix[test_index, 0:6] = copy[
-            test_index, len(glycan) : len(glycan) + 6
-        ]  # store original value
-        copy[
-            test_index, len(glycan) : len(glycan) + 6
-        ] = np.nan  # artificially make the value NaN
-
-        _, matrixFac, _ = perform_CMTF(cube, copy, components)  # run decomposition on new matrix
-        pred_matrix = tl.kruskal_to_tensor(matrixFac)
-        matrix[test_index, 6:13] = pred_matrix[
-            test_index, len(glycan) : len(glycan) + 6
-        ]  # store predicted values
-
-    return matrix
-
-
 def SVM_2class_predictions(subjects_matrix):
     """ Predict Subject Class with Support Vector Machines and Decomposed Tensor Data"""
     # Load Data

--- a/syserol/model.py
+++ b/syserol/model.py
@@ -1,4 +1,5 @@
 """ Regression methods using Factorized Data. """
+from functools import reduce
 import numpy as np
 import pandas as pd
 import tensorly as tl
@@ -9,7 +10,7 @@ from sklearn.metrics import r2_score, accuracy_score
 from sklearn.svm import SVC
 from tensorly.kruskal_tensor import kruskal_to_tensor
 from syserol.tensor import perform_CMTF
-from syserol.dataImport import createCube, importFunction, importGlycan, load_file
+from syserol.dataImport import createCube, importFunction, importGlycan, load_file, importLuminex, importIGG, getAxes
 
 
 def test_predictions(function="ADCD"):
@@ -56,7 +57,9 @@ def Function_Prediction_10FoldCV(components=10):
             test_index, len(glycan) : len(glycan) + 6
         ] = np.nan  # artificially make the value NaN
 
-        _, matrixFac, _ = perform_CMTF(cube, copy, components)  # run decomposition on new matrix
+        _, matrixFac, _ = perform_CMTF(
+            cube, copy, components
+        )  # run decomposition on new matrix
         pred_matrix = tl.kruskal_to_tensor(matrixFac)
         matrix[test_index, 6:13] = pred_matrix[
             test_index, len(glycan) : len(glycan) + 6
@@ -95,22 +98,75 @@ def SVM_2class_predictions(subjects_matrix):
 
     return cp_accuracy, nv_accuracy
 
+
 def noCMTF_function_prediction(components=6, function="ADCC"):
     cube, glyCube = createCube()
     tensorFac, matrixFac, _ = perform_CMTF(cube, glyCube, components)
 
     func, _ = importFunction()
-    df = pd.DataFrame(tensorFac[1][0]) #subjects x components matrix
-    df = df.join(func, how = 'inner')
+    df = pd.DataFrame(tensorFac[1][0])  # subjects x components matrix
+    df = df.join(func, how="inner")
     df = df.dropna()
     df_func = df[["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]]
-    df_variables = df.drop(['subject','ADCD', 'ADCC', 'ADNP', 'CD107a', 'IFNy', 'MIP1b'], axis = 1)
+    df_variables = df.drop(
+        ["subject", "ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"], axis=1
+    )
 
     X = df_variables
-    Y = df_func["ADCC"]
-    regr = ElasticNetCV(normalize=True, max_iter = 10000)
+    Y = df_func[function]
+    regr = ElasticNetCV(normalize=True, max_iter=10000)
     model = regr.fit(X, Y)
-    Y_pred = cross_val_predict(ElasticNet(alpha = regr.alpha_, normalize = True, max_iter = 10000), X, Y, cv = 10)
+    Y_pred = cross_val_predict(
+        ElasticNet(alpha=regr.alpha_, normalize=True, max_iter=10000), X, Y, cv=10
+    )
+
     print(f"Components: {components}, Accuracy: {np.sqrt(r2_score(Y, Y_pred))}")
 
     return Y, Y_pred, np.sqrt(r2_score(Y, Y_pred))
+
+
+def ourSubjects_function_prediction(components=6, function="ADCC"):
+    # Re-Create Alter DataFrame with leftout subjects
+    df = importLuminex()
+    lum = df.pivot(index="subject", columns="variable", values="value")
+    _, df2 = importGlycan()
+    glyc = df2.pivot(index="subject", columns="variable", values="value")
+    func, _ = importFunction()
+    igg = importIGG()
+    igg = igg.pivot(index="subject", columns="variable", values="value")
+    data_frames = [lum, glyc, func, igg]
+    df_merged = reduce(
+        lambda left, right: pd.merge(left, right, on=["subject"], how="inner"),
+        data_frames,
+    )
+    df_merged = df_merged.dropna()  # Final Alter DataFrame
+    fullsubj = np.array(df_merged["subject"])  # Subjects only included in Alter
+    leftout = []
+    subjects, _, _ = getAxes()
+    for index, i in enumerate(subjects):
+        if i not in fullsubj:
+            leftout.append((index, i))  # Subjects left out of Alter
+    indices = [i[0] for i in leftout]
+
+    cube, glyCube = createCube()
+    tensorFac, matrixFac, _ = perform_CMTF(cube, glyCube, components)
+
+    func, _ = importFunction()
+    df = pd.DataFrame(tensorFac[1][0])  # subjects x components matrix
+    df = df.join(func, how="inner")
+    df = df.iloc[indices]
+    df = df.dropna()
+    df_func = df[["ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"]]
+    df_variables = df.drop(
+        ["subject", "ADCD", "ADCC", "ADNP", "CD107a", "IFNy", "MIP1b"], axis=1
+    )
+
+    X = df_variables
+    Y = df_func[function]
+    regr = ElasticNetCV(normalize=True, max_iter=10000)
+    model = regr.fit(X, Y)
+    Y_pred = cross_val_predict(
+        ElasticNet(alpha=regr.alpha_, normalize=True, max_iter=10000), X, Y, cv=10
+    )
+
+    return Y, Y_pred


### PR DESCRIPTION
The reason I simply added a drop line instead of removing the adding of functions is because the dfGlycan originally only has 98 subjects. To keep the glyCube still 181x25, with NaNs filled where there are no glycan measurements, we can just drop the functions from the merged matrix. However, it's probably not the cleanest way to do it. I'm looking into just never adding the functions and filling with NaNs a different way but running into some strange problems with the DF.