### PR TITLE
binary cube

### DIFF
--- a/syserol/dataImport.py
+++ b/syserol/dataImport.py
@@ -120,6 +120,16 @@ def AlterIndices():
 
     return np.array([subjects.index(subject) for i, subject in enumerate(df["subject"])])
 
+def binaryCube():
+    cube, _ = createCube()
+    indices = AlterIndices()
+    notAlter = np.delete(np.arange(181), indices)
+
+    cube[indices, :, :] = True
+    cube[notAlter, : :] = False
+
+    return cube
+
 
 @lru_cache()
 def createCube():


### PR DESCRIPTION
I think this is the right way to see what was used in Alter. In their code, they run the predictions with data from luminex.csv, luminex-igg.csv, glycan-gp120.csv, which is essentially what we have from `AlterIndices`. However, I think we may have a bug... I think `AlterIndices` wants to call `importAlterDF` with `(False, False)` and not just on default features. I'm not sure how much the Functions being there makes a difference-might only be about 2 subjects but just a note to think about. Anyway, I can't see any way that they selected for certain receptor or antigen data in their code, so I think it's just based on the subsetted Alter subjects and we can use that to build the binary cube.