### PR TITLE
Made plot colors for Figures 2, 3, and 5 more consistent as per reviewer comment 5.2

### DIFF
--- a/syserol/figures/figure2.py
+++ b/syserol/figures/figure2.py
@@ -1,36 +1,28 @@
 """
 This creates Figure 2.
 """
-
 import numpy as np
 from statsmodels.multivariate.pca import PCA
 from .common import subplotLabel, getSetup
 from ..tensor import perform_CMTF
 from ..dataImport import functions, createCube
 from matplotlib.ticker import ScalarFormatter
-
-
 def makeFigure():
     """Get a list of the axis objects and create a figure"""
     # Get list of axis objects
     ax, f = getSetup((6, 3), (1, 2))
-
     comps = np.arange(1, 12)
     TMTFR2X = np.zeros(comps.shape)
     PCAR2X = np.zeros(comps.shape)
-
     tOrig, mOrig = createCube()
-
     tMat = np.reshape(tOrig, (181, -1))
     tMat = tMat[:, ~np.all(np.isnan(tMat), axis=0)]
     tMat = np.hstack((tMat, mOrig))
-
     sizePCA = comps * np.sum(tMat.shape)
     sizeTfac = comps * (np.sum(tOrig.shape) + mOrig.shape[1])
 
     for i, cc in enumerate(comps):
-        outt = PCA(tMat, ncomp=cc, missing="fill-em",
-                   standardize=False, demean=False, normalize=False)
+        outt = PCA(tMat, ncomp=cc, missing="fill-em", standardize=False, demean=False, normalize=False)
         recon = outt.scores @ outt.loadings.T
         PCAR2X[i] = np.nanvar(tMat - recon) / np.nanvar(tMat)
 
@@ -40,8 +32,7 @@ def makeFigure():
     ax[0].set_ylabel("TMTF R2X")
     ax[0].set_xlabel("Number of Components")
     ax[0].set_xticks([x for x in comps])
-    ax[0].set_xticklabels([x for x in comps])
-    ax[0].set_ylim(0, 1)
+	@@ -44,8 +45,8 @@ def makeFigure():
     ax[0].set_xlim(0.0, np.amax(comps) + 0.5)
 
     ax[1].set_xscale("log", base=2)
@@ -53,8 +44,6 @@ def makeFigure():
     ax[1].set_xlim(2 ** 8, 2 ** 12)
     ax[1].xaxis.set_major_formatter(ScalarFormatter())
     ax[1].legend()
-
     # Add subplot labels
     subplotLabel(ax)
-
     return f

--- a/syserol/figures/figure2.py
+++ b/syserol/figures/figure2.py
@@ -29,13 +29,14 @@ def makeFigure():
     sizeTfac = comps * (np.sum(tOrig.shape) + mOrig.shape[1])
 
     for i, cc in enumerate(comps):
-        outt = PCA(tMat, ncomp=cc, missing="fill-em", standardize=False, demean=False, normalize=False)
+        outt = PCA(tMat, ncomp=cc, missing="fill-em",
+                   standardize=False, demean=False, normalize=False)
         recon = outt.scores @ outt.loadings.T
         PCAR2X[i] = np.nanvar(tMat - recon) / np.nanvar(tMat)
 
         _, _, TMTFR2X[i] = perform_CMTF(r=cc)
 
-    ax[0].scatter(comps, TMTFR2X, color="k", s=10)
+    ax[0].scatter(comps, TMTFR2X, s=10)
     ax[0].set_ylabel("TMTF R2X")
     ax[0].set_xlabel("Number of Components")
     ax[0].set_xticks([x for x in comps])
@@ -44,8 +45,8 @@ def makeFigure():
     ax[0].set_xlim(0.0, np.amax(comps) + 0.5)
 
     ax[1].set_xscale("log", base=2)
-    ax[1].plot(sizePCA, PCAR2X, "r.", label="PCA")
-    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, "k.", label="TMTF")
+    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, ".", label="TMTF")
+    ax[1].plot(sizePCA, PCAR2X, ".", label="PCA")
     ax[1].set_ylabel("Normalized Unexplained Variance")
     ax[1].set_xlabel("Size of Factorization")
     ax[1].set_ylim(bottom=0.0)

--- a/syserol/figures/figure2.py
+++ b/syserol/figures/figure2.py
@@ -44,8 +44,8 @@ def makeFigure():
     ax[0].set_xlim(0.0, np.amax(comps) + 0.5)
 
     ax[1].set_xscale("log", base=2)
-    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, "k", label="TMTF")
-    ax[1].plot(sizePCA, PCAR2X, "r", label="PCA")
+    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, ".", label="TMTF")
+    ax[1].plot(sizePCA, PCAR2X, ".", label="PCA")
     ax[1].set_ylabel("Normalized Unexplained Variance")
     ax[1].set_xlabel("Size of Factorization")
     ax[1].set_ylim(bottom=0.0)

--- a/syserol/figures/figure2.py
+++ b/syserol/figures/figure2.py
@@ -1,23 +1,30 @@
 """
 This creates Figure 2.
 """
+
 import numpy as np
 from statsmodels.multivariate.pca import PCA
 from .common import subplotLabel, getSetup
 from ..tensor import perform_CMTF
 from ..dataImport import functions, createCube
 from matplotlib.ticker import ScalarFormatter
+
+
 def makeFigure():
     """Get a list of the axis objects and create a figure"""
     # Get list of axis objects
     ax, f = getSetup((6, 3), (1, 2))
+
     comps = np.arange(1, 12)
     TMTFR2X = np.zeros(comps.shape)
     PCAR2X = np.zeros(comps.shape)
+
     tOrig, mOrig = createCube()
+
     tMat = np.reshape(tOrig, (181, -1))
     tMat = tMat[:, ~np.all(np.isnan(tMat), axis=0)]
     tMat = np.hstack((tMat, mOrig))
+
     sizePCA = comps * np.sum(tMat.shape)
     sizeTfac = comps * (np.sum(tOrig.shape) + mOrig.shape[1])
 
@@ -32,18 +39,21 @@ def makeFigure():
     ax[0].set_ylabel("TMTF R2X")
     ax[0].set_xlabel("Number of Components")
     ax[0].set_xticks([x for x in comps])
-	@@ -44,8 +45,8 @@ def makeFigure():
+    ax[0].set_xticklabels([x for x in comps])
+    ax[0].set_ylim(0, 1)
     ax[0].set_xlim(0.0, np.amax(comps) + 0.5)
 
     ax[1].set_xscale("log", base=2)
-    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, ".", label="TMTF")
-    ax[1].plot(sizePCA, PCAR2X, ".", label="PCA")
+    ax[1].plot(sizeTfac, 1.0 - TMTFR2X, "k", label="TMTF")
+    ax[1].plot(sizePCA, PCAR2X, "r", label="PCA")
     ax[1].set_ylabel("Normalized Unexplained Variance")
     ax[1].set_xlabel("Size of Factorization")
     ax[1].set_ylim(bottom=0.0)
     ax[1].set_xlim(2 ** 8, 2 ** 12)
     ax[1].xaxis.set_major_formatter(ScalarFormatter())
     ax[1].legend()
+
     # Add subplot labels
     subplotLabel(ax)
+
     return f

--- a/syserol/figures/figure3.py
+++ b/syserol/figures/figure3.py
@@ -15,7 +15,7 @@ def makeFigure():
     comps = np.arange(1, 12)
 
     Q2X = evaluate_missing(comps)
-    ax[0].scatter(comps, Q2X, c='k')
+    ax[0].scatter(comps, Q2X)
     ax[0].set_ylabel("Q2X of Imputation")
     ax[0].set_xlabel("Number of Components")
     ax[0].set_xticks([x for x in comps])

--- a/syserol/figures/figure5.py
+++ b/syserol/figures/figure5.py
@@ -25,11 +25,10 @@ def makeFigure():
     accuracies = accuracies + preds + baselines
 
     # Create DataFrame
-    model = ["Alter et al"] * 6 + ["TMTF"] * 6 + ["Randomized"] * 6
+    model = ["TMTF"] * 6 + ["Alter et al"] * 6 + ["Randomized"] * 6
     function = functions + functions + functions
     data = {"Accuracy": accuracies, "Model": model, "Function": function}
-    # Function Prediction DataFrame, Figure 5A
-    functions_df = pd.DataFrame(data)
+    functions_df = pd.DataFrame(data)  # Function Prediction DataFrame, Figure 5A
 
     # Gather Class Prediction Accuracies
     accuracyCvP, accuracyVvN = two_way_classifications()  # Alter accuracies
@@ -37,12 +36,9 @@ def makeFigure():
     accuracy, _, _ = class_predictions(tFac[1][0])  # Our accuracies
 
     # Create DataFrame
-    # datasetEV3/Fc.array/class.nv/lambda.min/score_details.txt "No information rate"
-    baselineNV = 0.5083
-    # datasetEV3/Fc.array/class.cp/lambda.min/score_details.txt "No information rate"
-    baselineCP = 0.5304
-    accuracies = np.array([accuracyCvP, accuracy["cp_all"],
-                           baselineCP, accuracyVvN, accuracy["nv_all"], baselineNV])
+    baselineNV = 0.5083  # datasetEV3/Fc.array/class.nv/lambda.min/score_details.txt "No information rate"
+    baselineCP = 0.5304  # datasetEV3/Fc.array/class.cp/lambda.min/score_details.txt "No information rate"
+    accuracies = np.array([accuracyCvP, accuracy["cp_all"], baselineCP, accuracyVvN, accuracy["nv_all"], baselineNV])
     category = ["Controller/Progressor"] * 3 + ["Viremic/Non-Viremic"] * 3
     model = ["TMTF", "Alter et al", "Randomized"] * 2
     data = {"Accuracies": accuracies, "Class": category, "Model": model}
@@ -52,8 +48,7 @@ def makeFigure():
     ax, f = getSetup((6, 3), (1, 2))
     sns.set()
     # Function Plot
-    a = sns.scatterplot(y="Accuracy", x="Function", style="Model", hue="Model", data=functions_df, ax=ax[0], markers=[
-                        'o', 's'])
+    a = sns.scatterplot(y="Accuracy", x="Function", style="Model", hue="Model", data=functions_df, ax=ax[0])
     # Formatting
     shades = [-0.5, 1.5, 3.5]
     for i in shades:
@@ -69,9 +64,7 @@ def makeFigure():
     a.get_legend().remove()
 
     # Class Plot
-    b = sns.scatterplot(y="Accuracies", x="Class",
-                        style="Model", hue="Model", data=classes, ax=ax[1], markers=[
-                            'o', 's', 'X'])
+    b = sns.scatterplot(y="Accuracies", x="Class", style="Model", hue="Model", data=classes, ax=ax[1])
     # Formatting
     b.axvspan(-0.5, 0.5, alpha=0.1, color="grey")
     b.set_xlim(-0.5, 1.5)

--- a/syserol/figures/figure5.py
+++ b/syserol/figures/figure5.py
@@ -28,7 +28,8 @@ def makeFigure():
     model = ["Alter et al"] * 6 + ["TMTF"] * 6 + ["Randomized"] * 6
     function = functions + functions + functions
     data = {"Accuracy": accuracies, "Model": model, "Function": function}
-    functions_df = pd.DataFrame(data)  # Function Prediction DataFrame, Figure 5A
+    # Function Prediction DataFrame, Figure 5A
+    functions_df = pd.DataFrame(data)
 
     # Gather Class Prediction Accuracies
     accuracyCvP, accuracyVvN = two_way_classifications()  # Alter accuracies
@@ -36,11 +37,14 @@ def makeFigure():
     accuracy, _, _ = class_predictions(tFac[1][0])  # Our accuracies
 
     # Create DataFrame
-    baselineNV = 0.5083  # datasetEV3/Fc.array/class.nv/lambda.min/score_details.txt "No information rate"
-    baselineCP = 0.5304  # datasetEV3/Fc.array/class.cp/lambda.min/score_details.txt "No information rate"
-    accuracies = np.array([accuracyCvP, accuracy["cp_all"], baselineCP, accuracyVvN, accuracy["nv_all"], baselineNV])
+    # datasetEV3/Fc.array/class.nv/lambda.min/score_details.txt "No information rate"
+    baselineNV = 0.5083
+    # datasetEV3/Fc.array/class.cp/lambda.min/score_details.txt "No information rate"
+    baselineCP = 0.5304
+    accuracies = np.array([accuracyCvP, accuracy["cp_all"],
+                           baselineCP, accuracyVvN, accuracy["nv_all"], baselineNV])
     category = ["Controller/Progressor"] * 3 + ["Viremic/Non-Viremic"] * 3
-    model = ["Alter et al", "TMTF", "Randomized"] * 2
+    model = ["TMTF", "Alter et al", "Randomized"] * 2
     data = {"Accuracies": accuracies, "Class": category, "Model": model}
     classes = pd.DataFrame(data)  # Class Predictions DataFrame, Figure 5B
 
@@ -48,7 +52,8 @@ def makeFigure():
     ax, f = getSetup((6, 3), (1, 2))
     sns.set()
     # Function Plot
-    a = sns.scatterplot(y="Accuracy", x="Function", style="Model", hue="Model", data=functions_df, ax=ax[0])
+    a = sns.scatterplot(y="Accuracy", x="Function", style="Model", hue="Model", data=functions_df, ax=ax[0], markers=[
+                        'o', 's'])
     # Formatting
     shades = [-0.5, 1.5, 3.5]
     for i in shades:
@@ -64,7 +69,9 @@ def makeFigure():
     a.get_legend().remove()
 
     # Class Plot
-    b = sns.scatterplot(y="Accuracies", x="Class", style="Model", hue="Model", data=classes, ax=ax[1])
+    b = sns.scatterplot(y="Accuracies", x="Class",
+                        style="Model", hue="Model", data=classes, ax=ax[1], markers=[
+                            'o', 's', 'X'])
     # Formatting
     b.axvspan(-0.5, 0.5, alpha=0.1, color="grey")
     b.set_xlim(-0.5, 1.5)


### PR DESCRIPTION
Reviewer comment:
“5.2 As a minor point, it would be nice if the plot colors and plot markers were more consistent. For example, TMTF could be represented by black dots in Figures 2, 3, and 5. It is a small point, but it helps the reader associate the information between plots.”

Updated figures:

Figure 2:
![image](https://user-images.githubusercontent.com/20587215/113803884-4bb09000-9712-11eb-98bc-e5fd3f7ed7e8.png)

Figure 3:
![image](https://user-images.githubusercontent.com/20587215/113803898-50754400-9712-11eb-8eaf-6ccdd39bdcdd.png)

Figure 5:
![image](https://user-images.githubusercontent.com/20587215/113803906-55d28e80-9712-11eb-82c8-6699da5c8fc5.png)
